### PR TITLE
Update package path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > Harmonic Modular Scale Typography
 
-A Sass module to manage your project’s typographic scale using a [harmonic progression](https://en.wikipedia.org/wiki/Harmonic_progression_(mathematics)).
+A Sass module to manage your project’s typographic scale using a [harmonic progression](<https://en.wikipedia.org/wiki/Harmonic_progression_(mathematics)>).
 
 See the [explanatory article](https://standard.shiftbrain.com/blog/harmonious-proportions-in-type-sizes) for details (Japanese).
 
@@ -44,7 +44,7 @@ npm install @shiftbrainstd/harmonic-modular-scale
 Import the module in your Sass file:
 
 ```scss
-@use "harmonic-modular-scale" as hms;
+@use "@shiftbrainstd/harmonic-modular-scale" as hms;
 ```
 
 This module exposes a main function and a mixin:
@@ -85,12 +85,12 @@ $sizes: hms.get-sizes($list);
 
 The `get-line-height` function accepts the following arguments:
 
-| argument              | type   | default | description                                                                                                                 |
-| --------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `$font-size-degree`   | number | 0       | An integer indicating the font size in the harmonic scale. The returned value will be relative to the base font size.       |
-| `$line-height-degree` | number | null    | The increments of line height relative to the minimum height that can contain the current font size. It must be an integer. |
-| `$lines` | number | 1    | The number to multiply the line height for. |
-| `$as-line-height` | boolean | false | If true, returns the value relative to the current font-size. If false, returns the value relative to the root font size. |
+| argument              | type    | default | description                                                                                                                 |
+| --------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `$font-size-degree`   | number  | 0       | An integer indicating the font size in the harmonic scale. The returned value will be relative to the base font size.       |
+| `$line-height-degree` | number  | null    | The increments of line height relative to the minimum height that can contain the current font size. It must be an integer. |
+| `$lines`              | number  | 1       | The number to multiply the line height for.                                                                                 |
+| `$as-line-height`     | boolean | false   | If true, returns the value relative to the current font-size. If false, returns the value relative to the root font size.   |
 
 It will returns `line-hieght` value related to the `$base-font-size`. It is helpful when you need to set sizes based on typographic scale.
 
@@ -162,9 +162,9 @@ You can use the `get-sizes` function as the `polyrhythm-typography`’s type sca
 ```scss
 // main.scss
 @use "sass:meta";
-@use "harmonic-modular-scale";
+@use "@shiftbrainstd/harmonic-modular-scale";
 
-@use "polyrhythm-typography" as pt with (
+@use "@shiftbrainstd/polyrhythm-typography" as pt with (
   $type-scaler: meta.get-function("get-sizes", $module: "harmonic-modular-scale")
 );
 ```
@@ -192,7 +192,7 @@ npm run test
 
 ## 🤝 Contributing
 
-Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/devjam/harmonic-modular-scale/issues).
+Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/ShiftbrainStd/harmonic-modular-scale/issues).
 
 ## 📝 License
 


### PR DESCRIPTION
I updated the docs with the correct inclusion path (See https://github.com/ShiftbrainStd/polyrhythm-typography/issues/9).

It looks like the namespace is not used when using the `$module` parameter in functions like `meta.get-function`:

```scss
@use "sass:meta";
@use "@shiftbrainstd/harmonic-modular-scale";

// works
meta.get-function("get-sizes", $module: "harmonic-modular-scale")

// doesn't work
meta.get-function("get-sizes", $module: "@shiftbrainstd/harmonic-modular-scale")
```